### PR TITLE
Add `qf`s for City and Description in support of advanced search

### DIFF
--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -175,6 +175,16 @@
          subject_teim
       </str>
 
+      <str name="description_qf">
+         description_unstem_search^100000
+         description_tei
+      </str>
+
+      <str name="city_or_township_qf">
+        city_unstem_search^100000
+        city_ssim
+      </str>
+
        <int name="ps">3</int>
        <float name="tie">0.01</float>
 


### PR DESCRIPTION
This change adds support for advanced search fields, city and description.

We must merge and deploy this in order for https://github.com/Minitex/mdl_search/pull/63 to be effective