### PR TITLE
Add identifier_ssim to default qf

### DIFF
--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -118,6 +118,7 @@
          kaltura_video_ssi
          local_identifier_ssi
          identifier_ssi
+         identifier_ssim
 
          type_ssi
          type_tesi


### PR DESCRIPTION
This will allow for surfacing parent compound documents when searching
for the MDL identifier of one of their child documents.